### PR TITLE
feat: disable pagination actions if num_page is 1

### DIFF
--- a/lua/buffon/config.lua
+++ b/lua/buffon/config.lua
@@ -77,10 +77,13 @@ local Config = {}
 
 ---@param opts any
 function Config:new(opts)
-  local o = vim.tbl_deep_extend("force", default, opts or {})
-  setmetatable(o, self)
+  local cfg = vim.tbl_deep_extend("force", default, opts or {})
+  if cfg.num_pages < 1 or cfg.num_pages > 4 then
+    cfg.num_pages = 1
+  end
+  setmetatable(cfg, self)
   self.__index = self
-  return o
+  return cfg
 end
 
 M.Config = Config

--- a/lua/buffon/pagecontroller.lua
+++ b/lua/buffon/pagecontroller.lua
@@ -83,6 +83,9 @@ end
 
 ---@param pages table<table<BuffonBuffer>>
 local validate_data = function(config, pages)
+  if config.num_pages ~= #pages then
+    error("number of pages doesn't match")
+  end
   for idx = 1, config.num_pages do
     local buffers = pages[idx]
     for _, buffer in ipairs(buffers) do

--- a/lua/buffon/ui/mainwindow.lua
+++ b/lua/buffon/ui/mainwindow.lua
@@ -53,7 +53,9 @@ function MainWindow:refresh()
   local render = self.page_controller:get_active_page():render()
   self.window:set_content(render.content)
   self.window:set_highlight(render.highlights)
-  self.window:set_footer(self:footer())
+  if self.config.num_pages > 1 then
+    self.window:set_footer(self:footer())
+  end
   self.window:refresh_dimensions()
 end
 

--- a/tests/config_spec.lua
+++ b/tests/config_spec.lua
@@ -40,4 +40,13 @@ describe("config", function()
       },
     })
   end)
+
+  it("if num_pages is invalid, set default to 1", function()
+    local cfg = config.Config:new({ num_pages = 0 })
+    eq(cfg.num_pages, 1)
+
+    -- limot of num_pages is 4
+    local cfg2 = config.Config:new({ num_pages = 5 })
+    eq(cfg2.num_pages, 1)
+  end)
 end)

--- a/tests/maincontroller_spec.lua
+++ b/tests/maincontroller_spec.lua
@@ -40,8 +40,8 @@ describe("maincontrolelr", function()
     local stg = storage.Storage:new("/foo/boo")
     local pagectrl = pagecontroller.PageController:new(cfg)
     local ctrl = maincontroller.MainController:new(cfg, pagectrl, stg)
-    local shorcuts = ctrl:get_shortcuts()
-    compare_shortcuts(shorcuts, default_shortcuts)
+    local shortcuts = ctrl:get_shortcuts()
+    compare_shortcuts(shortcuts, default_shortcuts)
   end)
 
   it("disable close actions", function()
@@ -57,8 +57,8 @@ describe("maincontrolelr", function()
     local stg = storage.Storage:new("/foo/boo")
     local pagectrl = pagecontroller.PageController:new(cfg)
     local ctrl = maincontroller.MainController:new(cfg, pagectrl, stg)
-    local shorcuts = ctrl:get_shortcuts()
-    compare_shortcuts(shorcuts, {
+    local shortcuts = ctrl:get_shortcuts()
+    compare_shortcuts(shortcuts, {
       "toggle_buffon_window",
       "goto_next_buffer",
       "goto_previous_buffer",
@@ -84,7 +84,31 @@ describe("maincontrolelr", function()
     local stg = storage.Storage:new("/foo/boo")
     local pagectrl = pagecontroller.PageController:new(cfg)
     local ctrl = maincontroller.MainController:new(cfg, pagectrl, stg)
-    local shorcuts = ctrl:get_shortcuts()
-    compare_shortcuts(shorcuts, default_shortcuts)
+    local shortcuts = ctrl:get_shortcuts()
+    compare_shortcuts(shortcuts, default_shortcuts)
+  end)
+
+  it("if num_pages is 1, keybindings related with pagination are disabled", function()
+    local cfg = config.Config:new({ num_pages = 1 })
+    local stg = storage.Storage:new("/foo/boo")
+    local pagectrl = pagecontroller.PageController:new(cfg)
+    local ctrl = maincontroller.MainController:new(cfg, pagectrl, stg)
+    local shortcuts = ctrl:get_shortcuts()
+    compare_shortcuts(shortcuts, {
+      "toggle_buffon_window",
+      "goto_next_buffer",
+      "goto_previous_buffer",
+      "move_buffer_up",
+      "move_buffer_down",
+      "move_buffer_top",
+      "move_buffer_bottom",
+      "close_buffer",
+      "close_buffers_above",
+      "close_buffers_below",
+      "close_all_buffers",
+      "close_others",
+      "switch_previous_used_buffer",
+      "reopen_recent_closed_buffer",
+    })
   end)
 end)

--- a/tests/pagecontroller_spec.lua
+++ b/tests/pagecontroller_spec.lua
@@ -69,13 +69,11 @@ describe("page controller", function()
     local all_good_1, _ = pagectrl:validate_data({
       { { name = "foo", short_path = "foo", cursor = { 1, 1 }, short_name = "foo", filename = "foo" } },
       {},
-      {},
     })
     eq(all_good_1, true)
 
     local all_good_2, _ = pagectrl:validate_data({
       { { name = "foo", short_path = "foo", cursor = { 1, 1 }, short_name = "foo", filename = "foo", id = 1 } },
-      {},
       {},
     })
     eq(all_good_2, true)
@@ -83,13 +81,11 @@ describe("page controller", function()
     local id_is_missing, _ = pagectrl:validate_data({
       { { name = "foo", short_path = "foo", cursor = { 1, 1 }, short_name = "foo", filename = 1 }, {}, {} },
       {},
-      {},
     })
     eq(id_is_missing, false)
 
     local cursor_is_missing, _ = pagectrl:validate_data({
       { { name = "foo", short_path = "foo", short_name = "foo", filename = "foo", id = 1 }, {}, {} },
-      {},
       {},
     })
     eq(cursor_is_missing, false)
@@ -98,6 +94,13 @@ describe("page controller", function()
       { { name = "foo", short_path = "foo", cursor = { 1, 1 }, short_name = "foo", filename = "foo" } },
     })
     eq(invalid_groups_length, false)
+
+    local invalid_pages_number, _ = pagectrl:validate_data({
+      { { name = "foo", short_path = "foo", cursor = { 1, 1 }, short_name = "foo", filename = "foo" } },
+      {},
+      {},
+    })
+    eq(invalid_pages_number, false)
   end)
 
   it("navigate", function()


### PR DESCRIPTION
If `num_pages` is 1, actions related with the pagination are disabled.

* next_page
* previous_page
* move_to_next_page
* move_to_previous_page

Also, the page indicators is hide:

<img width="186" alt="imagen" src="https://github.com/user-attachments/assets/1c33f168-0eea-4b6f-9acb-831054054739" />

