### PR TITLE
fix: reindex buffers after renaming

### DIFF
--- a/lua/buffon/bufferslist.lua
+++ b/lua/buffon/bufferslist.lua
@@ -226,6 +226,7 @@ function BuffersList:rename(name, new_name)
   if idx then
     local buf = buffon_buffer.Buffer:new(self.buffers[idx].id, new_name)
     self.buffers[idx] = buf
+    self:reindex()
   end
 end
 

--- a/lua/buffon/maincontroller.lua
+++ b/lua/buffon/maincontroller.lua
@@ -523,11 +523,13 @@ end
 --------------------------------------------------------------------------------------------
 
 function MainController:event_buffer_will_rename(buf)
+  log.debug("buffer will be renamed", vim.fn.fnamemodify(buf.match, ":t"))
   self.buffer_will_be_renamed = buf.match
 end
 
 function MainController:event_rename_buffer(buf)
   assert(self.buffer_will_be_renamed, "new buffer name is required")
+  log.debug("set new name", vim.fn.fnamemodify(buf.match, ":t"))
   for _, page in ipairs(self.page_controller.pages) do
     page.bufferslist:rename(self.buffer_will_be_renamed, buf.match)
   end


### PR DESCRIPTION
A bug occurred when renaming a buffer. The buffer list failed to reindex after the rename, preventing proper navigation to the previous/next buffer.