### PR TITLE
feat: add shortcut to toggle window position

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,9 @@ Take a look at the default shortcuts for navigating between buffers, changing th
     move_buffer_top = "<s-t>",
     move_buffer_bottom = "<s-b>",
     toggle_buffon_window = "<buffonleader>n",
+    --- Toggle window position allows moving the main window position
+    --- between top-right and bottom-right positions
+    toggle_buffon_window_position = "<buffonleader>nn",
     switch_previous_used_buffer = "<buffonleader><buffonleader>",
     close_buffer = "<buffonleader>d",
     close_buffers_above = "<buffonleader>v",

--- a/lua/buffon/config.lua
+++ b/lua/buffon/config.lua
@@ -25,6 +25,9 @@ local default = {
     move_buffer_top = "<s-t>",
     move_buffer_bottom = "<s-b>",
     toggle_buffon_window = "<buffonleader>n",
+    --- Toggle window position allows moving the main window position
+    --- between top-right and bottom-right positions
+    toggle_buffon_window_position = "<buffonleader>nn",
     switch_previous_used_buffer = "<buffonleader><buffonleader>",
     close_buffer = "<buffonleader>d",
     close_buffers_above = "<buffonleader>v",
@@ -52,6 +55,7 @@ local default = {
 ---@field move_buffer_top string|false
 ---@field move_buffer_bottom string|false
 ---@field toggle_buffon_window string
+---@field toggle_buffon_window_position string
 ---@field switch_previous_used_buffer string|false
 ---@field close_buffer string|false
 ---@field close_buffers_above string|false

--- a/lua/buffon/maincontroller.lua
+++ b/lua/buffon/maincontroller.lua
@@ -94,6 +94,11 @@ function MainController:get_shortcuts()
       method = self.action_show_hide_buffon_window,
     },
     {
+      shortcut = "toggle_buffon_window_position",
+      help = "Toggle window position",
+      method = self.action_toggle_window_position,
+    },
+    {
       shortcut = "goto_next_buffer",
       help = "Next buffer",
       method = self.action_goto_next,
@@ -307,6 +312,10 @@ end
 
 function MainController:action_show_hide_buffon_window()
   self.main_window:toggle()
+end
+
+function MainController:action_toggle_window_position()
+  self.main_window.window:toggle_position_between_top_right_bottom_right()
 end
 
 function MainController:event_add_buffer(buf)

--- a/lua/buffon/ui/window.lua
+++ b/lua/buffon/ui/window.lua
@@ -151,6 +151,14 @@ function Window:refresh_dimensions()
   vim.api.nvim_win_set_config(self.win_id, cfg)
 end
 
+function Window:toggle_position_between_top_right_bottom_right()
+  if self.position == WIN_POSITION.TOP_RIGHT then
+    self.position = WIN_POSITION.BOTTOM_RIGHT
+  else
+    self.position = WIN_POSITION.TOP_RIGHT
+  end
+end
+
 M.Window = Window
 M.WIN_POSITIONS = WIN_POSITION
 

--- a/tests/config_spec.lua
+++ b/tests/config_spec.lua
@@ -25,6 +25,7 @@ describe("config", function()
         move_buffer_top = "<s-t>",
         move_buffer_bottom = "<s-b>",
         toggle_buffon_window = "<buffonleader>n",
+        toggle_buffon_window_position = "<buffonleader>nn",
         switch_previous_used_buffer = "<buffonleader><buffonleader>",
         close_buffer = "<buffonleader>d",
         close_buffers_above = "<buffonleader>v",

--- a/tests/maincontroller_spec.lua
+++ b/tests/maincontroller_spec.lua
@@ -15,6 +15,7 @@ end
 
 local default_shortcuts = {
   "toggle_buffon_window",
+  "toggle_buffon_window_position",
   "goto_next_buffer",
   "goto_previous_buffer",
   "next_page",
@@ -60,6 +61,7 @@ describe("maincontrolelr", function()
     local shortcuts = ctrl:get_shortcuts()
     compare_shortcuts(shortcuts, {
       "toggle_buffon_window",
+      "toggle_buffon_window_position",
       "goto_next_buffer",
       "goto_previous_buffer",
       "next_page",
@@ -96,6 +98,7 @@ describe("maincontrolelr", function()
     local shortcuts = ctrl:get_shortcuts()
     compare_shortcuts(shortcuts, {
       "toggle_buffon_window",
+      "toggle_buffon_window_position",
       "goto_next_buffer",
       "goto_previous_buffer",
       "move_buffer_up",


### PR DESCRIPTION
Added the default shortcut ';nn' to toggle the window position between top-right and bottom. This is useful for small screens where the window might overlap text.

<img width="1189" alt="image" src="https://github.com/user-attachments/assets/7cc1d5cd-7156-48ee-883e-8bb22173326f" />

<img width="1191" alt="image" src="https://github.com/user-attachments/assets/61c15e85-2d01-405a-a6f2-c57cf89b4e3c" />
