### PR TITLE
feat: don't show an error if opening a closed buffon window

### DIFF
--- a/lua/buffon/maincontroller.lua
+++ b/lua/buffon/maincontroller.lua
@@ -250,6 +250,10 @@ function MainController:get_events()
       vimevent = "BufFilePost",
       method = self.event_rename_buffer,
     },
+    {
+      vimevent = "WinClosed",
+      method = self.event_win_closed,
+    },
   }
 end
 
@@ -578,6 +582,13 @@ end
 
 function MainController:action_show_help()
   self.help_window:toggle(self:get_shortcuts())
+end
+
+function MainController:event_win_closed(win)
+  if tonumber(win.match) == self.main_window.window.win_id then
+    log.debug("someone closed the buffon window")
+    self.main_window.window:clear_ids()
+  end
 end
 
 M.MainController = MainController

--- a/lua/buffon/ui/help.lua
+++ b/lua/buffon/ui/help.lua
@@ -6,7 +6,6 @@ local M = {}
 ---@class BuffonHelpWindow
 ---@field config BuffonConfig
 ---@field window BuffonWindow
----@field content_set boolean
 local HelpWindow = {}
 
 ---@param cfg BuffonConfig
@@ -14,7 +13,6 @@ function HelpWindow:new(cfg)
   local o = {
     config = cfg,
     window = window.Window:new(" Buffon Help ", window.WIN_POSITIONS.BOTTOM_RIGHT),
-    content_set = false,
   }
 
   setmetatable(o, self)
@@ -25,33 +23,34 @@ end
 
 ---@param actions table<BuffonAction>
 function HelpWindow:toggle(actions)
-  if not self.content_set then
-    self.content_set = true
-
-    local max_length = 0
-    local highlight = { Constant = {} }
-
-    for _, action in ipairs(actions) do
-      local action_len = #utils.replace_leader(self.config, self.config.keybindings[action.shortcut])
-      if action_len > max_length then
-        max_length = action_len
-      end
-    end
-
-    local content = {}
-    for idx, action in ipairs(actions) do
-      local shortcut = utils.replace_leader(self.config, self.config.keybindings[action.shortcut])
-      local shortcut_padded = shortcut .. string.rep(" ", max_length - #shortcut)
-      local line = string.format("%s %s", shortcut_padded, action.help)
-      table.insert(content, line)
-      table.insert(highlight.Constant, { line = idx - 1, col_start = 0, col_end = max_length })
-    end
-
-    self.window:set_content(content)
-    self.window:set_highlight(highlight)
+  if self.window:is_open() then
+    self.window:hide()
+    return
   end
 
-  self.window:toggle()
+  local max_length = 0
+  local highlight = { Constant = {} }
+
+  for _, action in ipairs(actions) do
+    local action_len = #utils.replace_leader(self.config, self.config.keybindings[action.shortcut])
+    if action_len > max_length then
+      max_length = action_len
+    end
+  end
+
+  local content = {}
+  for idx, action in ipairs(actions) do
+    local shortcut = utils.replace_leader(self.config, self.config.keybindings[action.shortcut])
+    local shortcut_padded = shortcut .. string.rep(" ", max_length - #shortcut)
+    local line = string.format("%s %s", shortcut_padded, action.help)
+    table.insert(content, line)
+    table.insert(highlight.Constant, { line = idx - 1, col_start = 0, col_end = max_length })
+  end
+
+  self.window:show()
+  self.window:set_content(content)
+  self.window:set_highlight(highlight)
+  self.window:refresh_dimensions()
 end
 
 M.HelpWindow = HelpWindow

--- a/lua/buffon/ui/window.lua
+++ b/lua/buffon/ui/window.lua
@@ -29,7 +29,7 @@ function Window:new(title, position)
   local o = {
     title = title,
     win_id = nil,
-    buf_id = vim.api.nvim_create_buf(false, true),
+    buf_id = nil,
     position = position,
   }
   setmetatable(o, self)
@@ -41,6 +41,7 @@ function Window:show()
   if self.win_id then
     return
   end
+  self.buf_id = vim.api.nvim_create_buf(false, true)
   self.win_id = vim.api.nvim_open_win(self.buf_id, false, {
     title = self.title,
     title_pos = "right",
@@ -64,11 +65,21 @@ function Window:is_open()
 end
 
 function Window:hide()
+  if self.win_id and not vim.api.nvim_win_is_valid(self.win_id) then
+    self:clear_ids()
+  end
+
   if not self.win_id then
     return
   end
-  vim.api.nvim_win_close(self.win_id, true)
+
+  vim.api.nvim_win_close(self.win_id, false)
+  self:clear_ids()
+end
+
+function Window:clear_ids()
   self.win_id = nil
+  self.buf_id = nil
 end
 
 function Window:toggle()
@@ -116,7 +127,7 @@ function Window:set_highlight(highlights)
 end
 
 function Window:refresh_dimensions()
-  if not self.win_id then
+  if not self.win_id or not vim.api.nvim_win_is_valid(self.win_id) then
     return
   end
 


### PR DESCRIPTION
The motivation for this PR is to fix issue #78.

For unknown reasons, after installing the Startify plugin, the `buffon` window cannot be opened. Neovim assigns an invalid window ID to the `buffon`.

The first thing I did was to avoid opening invalid windows and suppress the annoying Vim error.

I'm still working on figuring out how to apply the final fix.
