### PR TITLE
feat: check if buf exists in another window and activate it

### DIFF
--- a/lua/buffon/maincontroller.lua
+++ b/lua/buffon/maincontroller.lua
@@ -383,7 +383,18 @@ function MainController:action_open_or_activate_buffer(buf)
   log.debug("open", buf.filename, "with id", buf.id)
 
   if buf.id then
-    pcall(vim.api.nvim_set_current_buf, buf.id)
+    -- If the buffer is in a different window than the active one, we will activate that window.
+    -- This is useful for split windows.
+    -- For example: We have the screen split with buffer A on the left and buffer B on the right.
+    -- If we are on the left (A) and want to switch to buffer B, instead of opening B on the left,
+    -- the right window will be activated.
+    local wins_id = vim.fn.win_findbuf(buf.id)
+    if wins_id and wins_id[1] then
+      log.debug("buffer is in another window", wins_id[1])
+      vim.api.nvim_set_current_win(wins_id[1])
+    else
+      pcall(vim.api.nvim_set_current_buf, buf.id)
+    end
   else
     vim.api.nvim_command("edit " .. buf.name)
     buf.id = vim.api.nvim_get_current_buf()


### PR DESCRIPTION
Useful functionality when working with split windows. If the buffer already exists in another window, that window is activated instead of opening it in the current window.


https://github.com/user-attachments/assets/4f88cbd7-43c1-4c85-8826-12e29b516bc9

