### PR TITLE
feat: allow theme color configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,12 @@ Take a look at the default shortcuts for navigating between buffers, changing th
       "gitrebase",
     },
   },
+  theme = {
+    unloaded_buffer = "#404040",
+    shortcut = "#CC7832",
+    active = "#51afef",
+    unsaved_indicator = "#f70067",
+  },
   leader_key = ";",
   mapping_chars = "qweryuiop",
   keybindings = {

--- a/lua/buffon/config.lua
+++ b/lua/buffon/config.lua
@@ -15,6 +15,12 @@ local default = {
       "gitrebase",
     },
   },
+  theme = {
+    unloaded_buffer = "#404040",
+    shortcut = "#CC7832",
+    active = "#51afef",
+    unsaved_indicator = "#f70067",
+  },
   leader_key = ";",
   mapping_chars = "qweryuiop",
   keybindings = {
@@ -69,6 +75,12 @@ local default = {
 ---@field move_to_previous_page string
 ---@field move_to_next_page string
 
+---@class BuffonTheme
+---@field unloaded_buffer string
+---@field shortcut string
+---@field active string
+---@field unsaved_indicator string
+
 ---@class BuffonConfig
 ---@field cyclic_navigation boolean -- If true, navigation between buffers will wrap around (cyclic navigation).
 ---@field num_pages number
@@ -87,7 +99,17 @@ function Config:new(opts)
   end
   setmetatable(cfg, self)
   self.__index = self
+
+  cfg:load_theme()
+
   return cfg
+end
+
+function Config:load_theme()
+  vim.api.nvim_set_hl(0, "BuffonUnloadedBuffer", { fg = self.theme.unloaded_buffer })
+  vim.api.nvim_set_hl(0, "BuffonShortcut", { fg = self.theme.shortcut })
+  vim.api.nvim_set_hl(0, "BuffonLineActive", { fg = self.theme.active })
+  vim.api.nvim_set_hl(0, "BuffonUnsavedIndicator", { fg = self.theme.unsaved_indicator })
 end
 
 M.Config = Config

--- a/lua/buffon/page.lua
+++ b/lua/buffon/page.lua
@@ -8,10 +8,10 @@ local M = {}
 
 ---@enum theme
 local THEME = {
-  UnloadedBuffers = "LineNr",
-  Shortcut = "Constant",
-  LineActive = "Label",
-  ModifiedIndicator = "ErrorMsg",
+  UnloadedBuffers = "BuffonUnloadedBuffer",
+  Shortcut = "BuffonShortcut",
+  LineActive = "BuffonLineActive",
+  ModifiedIndicator = "BuffonUnsavedIndicator",
 }
 
 local WHITESPACE = 1

--- a/lua/buffon/ui/help.lua
+++ b/lua/buffon/ui/help.lua
@@ -29,7 +29,7 @@ function HelpWindow:toggle(actions)
   end
 
   local max_length = 0
-  local highlight = { Constant = {} }
+  local highlight = { BuffonShortcut = {} }
 
   for _, action in ipairs(actions) do
     local action_len = #utils.replace_leader(self.config, self.config.keybindings[action.shortcut])
@@ -44,7 +44,7 @@ function HelpWindow:toggle(actions)
     local shortcut_padded = shortcut .. string.rep(" ", max_length - #shortcut)
     local line = string.format("%s %s", shortcut_padded, action.help)
     table.insert(content, line)
-    table.insert(highlight.Constant, { line = idx - 1, col_start = 0, col_end = max_length })
+    table.insert(highlight.BuffonShortcut, { line = idx - 1, col_start = 0, col_end = max_length })
   end
 
   self.window:show()

--- a/tests/config_spec.lua
+++ b/tests/config_spec.lua
@@ -15,6 +15,12 @@ describe("config", function()
           "gitrebase",
         },
       },
+      theme = {
+        unloaded_buffer = "#404040",
+        shortcut = "#CC7832",
+        active = "#51afef",
+        unsaved_indicator = "#f70067",
+      },
       leader_key = ";",
       mapping_chars = "qweryuiop",
       keybindings = {

--- a/tests/page_spec.lua
+++ b/tests/page_spec.lua
@@ -35,7 +35,7 @@ describe("page", function()
       "   buffer10.lua ",
     })
 
-    eq(render.highlights.Constant, {
+    eq(render.highlights.BuffonShortcut, {
       {
         col_end = 2,
         col_start = 0,
@@ -83,9 +83,9 @@ describe("page", function()
       },
     })
 
-    eq(render.highlights.ErrorMsg, {})
+    eq(render.highlights.BuffonUnsavedIndicator, {})
 
-    eq(render.highlights.Label, {
+    eq(render.highlights.BuffonLineActive, {
       {
         col_end = 18,
         col_start = 3,
@@ -93,7 +93,7 @@ describe("page", function()
       },
     })
 
-    eq(render.highlights.LineNr, {
+    eq(render.highlights.BuffonUnloadedBuffer, {
       {
         col_end = 18,
         col_start = 0,


### PR DESCRIPTION
This feature enhances theme customization. It allows the user, through the configuration settings, to define colors for specific UI elements.

It is now possible to configure the colors for:
- The active buffer
- Displayed shortcuts / key indicators*
- Inactive / non-selected buffers
- The modified (unsaved) buffer indicator