### PR TITLE
fix: windows path backslashes can cause trouble

### DIFF
--- a/lua/buffon/buffer.lua
+++ b/lua/buffon/buffer.lua
@@ -29,9 +29,9 @@ function Buffer:new(id, name)
   local o = {
     id = id,
     name = name,
+    filename = vim.fn.fnamemodify(name, ":t"),
     short_name = vim.fn.fnamemodify(name, ":."):gsub("\\", "/"),
-    filename = vim.fn.fnamemodify(name, ":t"):gsub("\\", "/"),
-    short_path = M.abbreviate_path(vim.fn.fnamemodify(name, ":.")),
+    short_path = M.abbreviate_path(vim.fn.fnamemodify(name, ":.")):gsub("\\", "/"),
     cursor = { 1, 1 },
   }
   setmetatable(o, self)

--- a/lua/buffon/buffer.lua
+++ b/lua/buffon/buffer.lua
@@ -29,8 +29,8 @@ function Buffer:new(id, name)
   local o = {
     id = id,
     name = name,
-    short_name = vim.fn.fnamemodify(name, ":."),
-    filename = vim.fn.fnamemodify(name, ":t"),
+    short_name = vim.fn.fnamemodify(name, ":."):gsub("\\", "/"),
+    filename = vim.fn.fnamemodify(name, ":t"):gsub("\\", "/"),
     short_path = M.abbreviate_path(vim.fn.fnamemodify(name, ":.")),
     cursor = { 1, 1 },
   }


### PR DESCRIPTION
Backslashes can cause trouble. This is the only location where I saw the wrong backslash thing happening.

PS. What do you think about the tabs?