### PR TITLE
feat: return ctrl in setup function

### DIFF
--- a/lua/buffon/init.lua
+++ b/lua/buffon/init.lua
@@ -25,6 +25,8 @@ M.setup = function(opts)
   local ctrl = maincontroller.MainController:new(cfg, pagectrl, stg)
   ctrl:register_shortcuts()
   ctrl:register_events()
+
+  return ctrl
 end
 
 return M


### PR DESCRIPTION
I think its useful to return the main controller so that every one can configure the controller in their config and it doesn't even introduce breaking changes, so no downsides.