### PR TITLE
feat: allow disabling keybindings with an empty string

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ The keybindings shown in the following list can be deactivated. The reason for t
 }
 ```
 
-To do this, you only have to assign the string "false" in the configuration. For example:
+To do this, you only have to assign the string "false" or leave it blank in the configuration. For example:
 
 
 ```lua
@@ -191,7 +191,7 @@ To do this, you only have to assign the string "false" in the configuration. For
   opts = {
     keybindings = {
       close_buffer = "false"
-      close_others = "false"
+      close_others = ""
     },
   },
 }

--- a/lua/buffon/maincontroller.lua
+++ b/lua/buffon/maincontroller.lua
@@ -38,9 +38,6 @@ local pagination_actions = {
 ---@param rhs function | string The right-hand side of the keymap.
 ---@param help string The description of the keymap.
 local set_keymap = function(lhs, rhs, help)
-  if lhs == "" then
-    return
-  end
   vim.keymap.set("n", lhs, rhs, { silent = true, desc = "Buffon: " .. help })
 end
 
@@ -196,7 +193,8 @@ function MainController:get_shortcuts()
   local valid_shortcuts = {}
   for _, action in ipairs(shortcuts) do
     local action_can_be_disabled = configurable_disabled_actions[action.shortcut]
-    local action_is_disabled = self.config.keybindings[action.shortcut] == "false"
+    local action_is_disabled = (self.config.keybindings[action.shortcut] == "false")
+      or (self.config.keybindings[action.shortcut] == "")
     local is_pagination_action = pagination_actions[action.shortcut]
     local one_page = self.config.num_pages == 1
 

--- a/lua/buffon/ui/help.lua
+++ b/lua/buffon/ui/help.lua
@@ -41,16 +41,10 @@ function HelpWindow:toggle(actions)
   local content = {}
   for idx, action in ipairs(actions) do
     local shortcut = utils.replace_leader(self.config, self.config.keybindings[action.shortcut])
-		if shortcut == "" then
-      goto continue
-    end
-
     local shortcut_padded = shortcut .. string.rep(" ", max_length - #shortcut)
     local line = string.format("%s %s", shortcut_padded, action.help)
     table.insert(content, line)
     table.insert(highlight.BuffonShortcut, { line = idx - 1, col_start = 0, col_end = max_length })
-
-    ::continue::
   end
 
   self.window:show()

--- a/tests/maincontroller_spec.lua
+++ b/tests/maincontroller_spec.lua
@@ -45,12 +45,12 @@ describe("maincontrolelr", function()
     compare_shortcuts(shortcuts, default_shortcuts)
   end)
 
-  it("disable close actions", function()
+  it("disabling some actions", function()
     local cfg = config.Config:new({
       keybindings = {
         close_buffer = "false",
         close_buffers_above = "false",
-        close_buffers_below = "false",
+        close_buffers_below = "",
         close_all_buffers = "false",
         close_others = "false",
       },


### PR DESCRIPTION
fixes #10 

Hi @TheLazyCat00, could you take a look at this PR, please? It improves the functionality for disabling keybindings by allowing an empty string.

Thanks