### PR TITLE
feat: sort buffers by loaded status

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Take a look at the default shortcuts for navigating between buffers, changing th
   ignore_buff_names = {
     "diffpanel_",
   },
+  sort_buffers_by_loaded_status = false,
   theme = {
     unloaded_buffer = "#404040",
     shortcut = "#CC7832",

--- a/lua/buffon/buffer.lua
+++ b/lua/buffon/buffer.lua
@@ -23,7 +23,7 @@ M.abbreviate_path = function(path)
   return "/" .. table.concat(parts, "/", start_index)
 end
 
----@param id number
+---@param id number?
 ---@param name string
 function Buffer:new(id, name)
   local o = {

--- a/lua/buffon/bufferslist.lua
+++ b/lua/buffon/bufferslist.lua
@@ -73,7 +73,37 @@ function BuffersList:add(buffer, index_of_active_buffer)
       table.insert(self.buffers, position, buffer)
     end
   end
+
+  self:sort_buffers_by_loaded_status(false)
   self:reindex()
+end
+
+---@param reindex boolean
+function BuffersList:sort_buffers_by_loaded_status(reindex)
+  if not self.config.sort_buffers_by_loaded_status then
+    return
+  end
+
+  local table1 = {}
+  local table2 = {}
+
+  for _, buffer in ipairs(self.buffers) do
+    if buffer.id ~= nil then
+      table.insert(table1, buffer)
+    else
+      table.insert(table2, buffer)
+    end
+  end
+
+  for i = 1, #table2 do
+    table.insert(table1, table2[i])
+  end
+
+  self.buffers = table1
+
+  if reindex then
+    self:reindex()
+  end
 end
 
 ---@param name string

--- a/lua/buffon/config.lua
+++ b/lua/buffon/config.lua
@@ -24,6 +24,7 @@ local default = {
   ignore_buff_names = {
     "diffpanel_",
   },
+  sort_buffers_by_loaded_status = false,
   theme = {
     unloaded_buffer = "#404040",
     shortcut = "#CC7832",

--- a/lua/buffon/maincontroller.lua
+++ b/lua/buffon/maincontroller.lua
@@ -436,6 +436,9 @@ function MainController:action_open_or_activate_buffer(buf)
     if not set_cursor_success then
       vim.api.nvim_win_set_cursor(0, { 1, 1 })
     end
+
+    self.page_controller:get_active_page().bufferslist:sort_buffers_by_loaded_status(true)
+    self.main_window:refresh()
   end
 end
 

--- a/tests/bufferslist_spec.lua
+++ b/tests/bufferslist_spec.lua
@@ -6,6 +6,7 @@ local buffer = require("buffon.buffer")
 local buf1 = buffer.Buffer:new(1, "buffer1.lua")
 local buf2 = buffer.Buffer:new(2, "buffer2.lua")
 local buf3 = buffer.Buffer:new(3, "buffer3.lua")
+local buf4 = buffer.Buffer:new(4, "buffer4.lua")
 
 describe("buffers list", function()
   it("instantation", function()
@@ -236,5 +237,32 @@ describe("buffers list", function()
     list:add(buffer.Buffer:new(1, "diffpanel_3"))
     list:add(buffer.Buffer:new(1, "/foo/bar/diffpanel_3"))
     eq(list.buffers, {})
+  end)
+
+  it("add buffers having unloaded buffers", function()
+    -- initial state
+    local cfg = config.Config:new({ sort_buffers_by_loaded_status = true })
+    local list = bufferslist.BuffersList:new(cfg)
+
+    list:set_buffers({
+      buffer.Buffer:new(nil, "buffer1.lua"),
+      buffer.Buffer:new(nil, "buffer2.lua"),
+    })
+
+    eq(list.buffers[1].id, nil)
+    eq(list.buffers[2].id, nil)
+
+    -- add buffer3. the expected buffers list, should be: buffer3, buffer1, buffer2
+    list:add(buf3)
+    eq(list.buffers[1].id, buf3.id)
+    eq(list.buffers[2].id, nil)
+    eq(list.buffers[3].id, nil)
+
+    -- add buffer4. the expected buffers list, should be: buffer3, buffer4, buffer1, buffer2
+    list:add(buf4)
+    eq(list.buffers[1].id, buf3.id)
+    eq(list.buffers[2].id, buf4.id)
+    eq(list.buffers[3].id, nil)
+    eq(list.buffers[4].id, nil)
   end)
 end)

--- a/tests/config_spec.lua
+++ b/tests/config_spec.lua
@@ -22,6 +22,7 @@ describe("config", function()
       ignore_buff_names = {
         "diffpanel_",
       },
+      sort_buffers_by_loaded_status = false,
       theme = {
         unloaded_buffer = "#404040",
         shortcut = "#CC7832",


### PR DESCRIPTION
This feature sorts the buffers by status, placing the loaded ones at the top and the unloaded ones at the bottom.

![image](https://github.com/user-attachments/assets/e084f132-232d-45d4-862f-cc48da525580)
